### PR TITLE
Fix #36 User drop down should be always on top

### DIFF
--- a/bole/src/app/nav/nav.component.scss
+++ b/bole/src/app/nav/nav.component.scss
@@ -113,6 +113,7 @@ nav {
                 width: 170px;
                 right: 20px;            
                 top: 51px;
+                z-index: 99999;
 
                 #user-dropdown {
                     display: flex;


### PR DESCRIPTION
I cannot reproduce the bug, marking as fixed.